### PR TITLE
Update Jenkinsfile with SonarCloud URL

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
     // patterns that suggest potential bugs.
     stage('Static Analysis') {
       steps {
-        sh './gradlew sonarqube'
+        sh './gradlew sonarqube -Dsonar.host.url=${SONAR_HOST_URL}'
         // wait for sonarqube to finish its analysis
         sleep 5
         sh './gradlew checkQualityGate'


### PR DESCRIPTION
Updated the Jenkinsfile to include the SonarCloud URL for the Sonar scan step.

- Added environment variable SONAR_HOST_URL with the value 'https://sonarcloud.io/projects'
- Updated the Static Analysis stage to use the SonarCloud URL.

This change ensures that the Sonar scan uses the specified SonarCloud URL for analysis.